### PR TITLE
Fix dependency resolution conflicted on fasterxml jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.10.0.pr1</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Reptoro is deployed on devel indy preview, log complains http://pastebin.test.redhat.com/1109233, it seems that an error for maven dependency resolution conflicted on fasterxml jackson.
Current dependency trees:
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.9:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.0.pr1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.9:compile
It may need com.fasterxml.jackson.core:jackson-databind new version 2.9.9 instead of 2.10.0.pr1.